### PR TITLE
241012 유석환 소득/소비, 홈화면, 목표자산관리, 로그인 수정

### DIFF
--- a/src/components/consume/ConsumeCategorySum.vue
+++ b/src/components/consume/ConsumeCategorySum.vue
@@ -77,9 +77,11 @@
   import { Chart as ChartJS, Title, Tooltip, Legend, ArcElement, CategoryScale, LinearScale, DoughnutController } from 'chart.js';
   import { nextTick, onMounted, ref, watch } from 'vue';
   import axiosinstance from '@/AxiosInstance';
-  
+  import {useRouter} from 'vue-router'
+
   ChartJS.register(Title, Tooltip, Legend, ArcElement, CategoryScale, LinearScale, DoughnutController);
   
+  const router = useRouter();
   const month = useMonthStore();
   const doughnutChart = ref(null);
   let chartInstance = null;
@@ -116,8 +118,7 @@
       selectedCategory.value = category;
       filteredItems.value = categories.value.slice(4);
     } else {
-      selectedCategory.value = category;
-      filteredItems.value = categories.value.filter(item => item.category === category.category);
+      router.push({ path: '/budget/list'});
     }
     showDetailModal.value = true;
   };

--- a/src/components/consume/ConsumeCompareMonth.vue
+++ b/src/components/consume/ConsumeCompareMonth.vue
@@ -1,243 +1,256 @@
 <template>
-    <div class="wrapper">
+  <div class="wrapper">
+    <div style="width: 1000px">
+      <div class="text-left category-comparison">
+        <div class="main-title">전달 소비 누계 비교</div>
+      </div>
 
-        <div style="width: 1000px;">
-            <div class="text-left category-comparison">
-                <div class="main-title">전달 소비 누계 비교</div>
-            </div>
+      <!-- 설명 문구 부분 -->
+      <div class="consumeCompareTitle">
+        저번 달보다
+        <span
+          :class="{ 'highlight-more': totalDifference > 0, 'highlight-less': totalDifference <= 0 }"
+        >
+          {{ differenceMessage }}원 {{ totalDifference > 0 ? ' 더' : ' 덜' }} 썼어요!
+        </span>
+      </div>
 
-                <!-- 설명 문구 부분 -->
-                <div class="consumeCompareTitle">
-                    저번 달보다 
-                    <span :class="{'highlight-more': totalDifference > 0, 'highlight-less': totalDifference <= 0}">
-                    {{ differenceMessage }}원 {{ totalDifference > 0 ? '더 ' : '덜 ' }}
-                    </span>
-                    썼어요!
-                </div>
-
-                <!-- 그래프 부분 -->
-                <div class="graphWrapper">
-                    <div class="graph">
-                        <canvas ref="lineChart"></canvas>
-                    </div>
-                </div>
-            </div>
+      <!-- 그래프 부분 -->
+      <div class="graphWrapper">
+        <div class="graph">
+          <canvas ref="lineChart"></canvas>
         </div>
-       
+      </div>
+    </div>
+  </div>
 </template>
 
 <script setup>
-import { useMonthStore } from '@/stores/consume/curMonth';
-import { Chart as ChartJS, LineElement, PointElement, LineController, CategoryScale, LinearScale } from 'chart.js';
-import { nextTick, onMounted, ref, watch } from 'vue';
-import axiosinstance from '@/AxiosInstance';
+import { useMonthStore } from '@/stores/consume/curMonth'
+import {
+  Chart as ChartJS,
+  LineElement,
+  PointElement,
+  LineController,
+  CategoryScale,
+  LinearScale
+} from 'chart.js'
+import { nextTick, onMounted, ref, watch } from 'vue'
+import axiosinstance from '@/AxiosInstance'
 
-ChartJS.register(LineElement, PointElement, LineController, CategoryScale, LinearScale);
+ChartJS.register(LineElement, PointElement, LineController, CategoryScale, LinearScale)
 
-const month = useMonthStore();
-const lineChart = ref(null);
-let chartInstance = null;
+const month = useMonthStore()
+const lineChart = ref(null)
+let chartInstance = null
 
-const curMonth = ref([]);
-const prevMonth = ref([]);
-const today = new Date();
-const currentYear = today.getFullYear();
-const currentMonth = today.getMonth() + 1;
-const currentDay = today.getDate();
-const days = Array.from({ length: 31 }, (_, i) => i + 1);
+const curMonth = ref([])
+const prevMonth = ref([])
+const today = new Date()
+const currentYear = today.getFullYear()
+const currentMonth = today.getMonth() + 1
+const currentDay = today.getDate()
+const days = Array.from({ length: 31 }, (_, i) => i + 1)
 
-const differenceMessage = ref('');
-let totalDifference = 0;
+const differenceMessage = ref('')
+let totalDifference = 0
 
 const renderLineChart = async () => {
-    await nextTick();
+  await nextTick()
 
-    if (chartInstance) {
-        chartInstance.destroy();
-    }
+  if (chartInstance) {
+    chartInstance.destroy()
+  }
 
-    const ctx = lineChart.value.getContext('2d');
+  const ctx = lineChart.value.getContext('2d')
 
-    await axiosinstance.get(`/outcome/category/dailysum/${month.year}/${month.month}`)
-        .then(response => {
-            if (month.year === currentYear && month.month === currentMonth) {
-                curMonth.value = response.data.response.data.prices.slice(0, currentDay);
-            } else {
-                curMonth.value = response.data.response.data.prices;
+  await axiosinstance
+    .get(`/outcome/category/dailysum/${month.year}/${month.month}`)
+    .then((response) => {
+      if (month.year === currentYear && month.month === currentMonth) {
+        curMonth.value = response.data.response.data.prices.slice(0, currentDay)
+      } else {
+        curMonth.value = response.data.response.data.prices
+      }
+    })
+    .catch((error) => {
+      console.log(error)
+    })
+
+  await axiosinstance
+    .get(`/outcome/category/dailysum/${month.getPrevMonth.year}/${month.getPrevMonth.month}`)
+    .then((response) => {
+      prevMonth.value = response.data.response.data.prices
+    })
+    .catch((error) => {
+      console.log(error)
+    })
+
+  const curValue = curMonth.value[currentDay - 1] || 0
+  const prevValue = prevMonth.value[currentDay - 1] || 0
+
+  totalDifference = curValue - prevValue
+
+  differenceMessage.value = `${Math.abs(totalDifference).toLocaleString()}`
+
+  chartInstance = new ChartJS(lineChart.value, {
+    type: 'line',
+    data: {
+      labels: days,
+      datasets: [
+        {
+          label: month.month + '월',
+          data: curMonth.value,
+          fill: false, // 현재 월은 채우지 않음
+          borderColor: '#FF0062',
+          borderWidth: 2,
+          borderCapStyle: 'round',
+          borderJoinStyle: 'round',
+          tension: 0.4,
+          pointRadius: days.map((day) => {
+            if (month.year === currentYear && month.month === currentMonth && day === currentDay) {
+              return 6
             }
-        })
-        .catch(error => {
-            console.log(error);
-        });
-
-    await axiosinstance.get(`/outcome/category/dailysum/${month.getPrevMonth.year}/${month.getPrevMonth.month}`)
-        .then(response => {
-            prevMonth.value = response.data.response.data.prices;
-        })
-        .catch(error => {
-            console.log(error);
-        });
-
-    const curValue = curMonth.value[currentDay - 1] || 0;
-    const prevValue = prevMonth.value[currentDay - 1] || 0;
-
-    totalDifference = curValue - prevValue;
-
-    differenceMessage.value = `${Math.abs(totalDifference).toLocaleString()}`;
-
-    chartInstance = new ChartJS(lineChart.value, {
-        type: 'line',
-        data: {
-            labels: days,
-            datasets: [{
-                label: month.month + '월',
-                data: curMonth.value,
-                fill: false, // 현재 월은 채우지 않음
-                borderColor: '#FF0062',
-                borderWidth: 2,
-                borderCapStyle: 'round',
-                borderJoinStyle: 'round',
-                tension: 0.4,
-                pointRadius: days.map(day => {
-                    if (month.year === currentYear && month.month === currentMonth && day === currentDay) {
-                        return 6;
-                    }
-                    return 0;
-                }),
-                pointBackgroundColor: '#FF0062',
-            },
-            {
-                label: month.getPrevMonth.month + '월',
-                data: prevMonth.value,
-                fill: true, // 그라데이션 채우기
-                borderColor: '#D1D6D9',
-                borderWidth: 2,
-                borderCapStyle: 'round',
-                borderJoinStyle: 'round',
-                tension: 0.4,
-                pointRadius: 0,
-                backgroundColor: function(context) {
-                    const chart = context.chart;
-                    const {ctx, chartArea} = chart;
-
-                    if (!chartArea) {
-                        return null;
-                    }
-
-                    const gradient = ctx.createLinearGradient(0, chartArea.bottom, 0, chartArea.top);
-                    gradient.addColorStop(0, 'rgba(209, 214, 217, 0)'); // 아래쪽 투명
-                    gradient.addColorStop(1, 'rgba(209, 214, 217, 0.5)'); // 위쪽 반투명
-                    return gradient;
-                }
-            }]
+            return 0
+          }),
+          pointBackgroundColor: '#FF0062'
         },
-        options: {
-            responsive: true,
-            plugins: {
-                legend: {
-                    position: 'bottom',
-                    labels: {
-                        boxWidth: 20,
-                        padding: 20,
-                    },
-                },
-            },
-            elements: {
-                line: {
-                    tension: 0.4
-                },
-                point: {
-                    radius: 0
-                }
-            },
-            scales: {
-                x: {
-                    grid: {
-                        display: false,
-                    }
-                },
-                y: {
-                    display: false,
-                    grid: {
-                        display: false,
-                    }
-                }
+        {
+          label: month.getPrevMonth.month + '월',
+          data: prevMonth.value,
+          fill: true, // 그라데이션 채우기
+          borderColor: '#D1D6D9',
+          borderWidth: 2,
+          borderCapStyle: 'round',
+          borderJoinStyle: 'round',
+          tension: 0.4,
+          pointRadius: 0,
+          backgroundColor: function (context) {
+            const chart = context.chart
+            const { ctx, chartArea } = chart
+
+            if (!chartArea) {
+              return null
             }
+
+            const gradient = ctx.createLinearGradient(0, chartArea.bottom, 0, chartArea.top)
+            gradient.addColorStop(0, 'rgba(209, 214, 217, 0)') // 아래쪽 투명
+            gradient.addColorStop(1, 'rgba(209, 214, 217, 0.5)') // 위쪽 반투명
+            return gradient
+          }
         }
-    });
+      ]
+    },
+    options: {
+      responsive: true,
+      plugins: {
+        legend: {
+          position: 'bottom',
+          labels: {
+            boxWidth: 20,
+            padding: 20
+          }
+        }
+      },
+      elements: {
+        line: {
+          tension: 0.4
+        },
+        point: {
+          radius: 0
+        }
+      },
+      scales: {
+        x: {
+          grid: {
+            display: false
+          }
+        },
+        y: {
+          display: false,
+          grid: {
+            display: false
+          }
+        }
+      }
+    }
+  })
 }
 
 onMounted(() => {
-    renderLineChart();
-});
+  renderLineChart()
+})
 
-watch(() => month.month, () => {
-    renderLineChart();
-});
+watch(
+  () => month.month,
+  () => {
+    renderLineChart()
+  }
+)
 </script>
 
 <style scoped>
 * {
-    font-family: 'Pretendard', sans-serif;
-    font-size: 18px;
-  }
-  
-  .wrapper {
-    width:1000px;
-    margin: 0 auto;
-    padding: 20px;
-  }
+  font-family: 'Pretendard', sans-serif;
+  font-size: 18px;
+}
+
+.wrapper {
+  width: 1000px;
+  margin: 0 auto;
+  padding: 20px;
+}
 /* 설명 문구 스타일 */
 .consumeCompareTitle {
-    margin-top: 8px;
-    flex-shrink: 0;
-    border-radius: 20px;
-    background: #FAFAFB;
-    display: flex;
-    height: 120px;
-    padding: 10px;
-    justify-content: center;
-    align-items: center;
-    border: 1px solid #f8f8f8;
+  margin-top: 8px;
+  flex-shrink: 0;
+  border-radius: 20px;
+  background: #fafafb;
+  display: flex;
+  height: 120px;
+  padding: 10px;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid #f8f8f8;
 }
 
 /* 클래스 기반으로 색상 변경 */
 .highlight-more {
-    color: #FF0062;
-    font-weight: 500;
+  color: #ff0062;
+  font-weight: 500;
 }
 
 .highlight-less {
-    color: #0062FF;
-    font-weight: 500;
+  color: #0062ff;
+  font-weight: 500;
 }
 
 .graphWrapper {
-    margin-top: 8px;
-    padding: 20px;
-    background-color: #ffffff;
-    border-radius: 15px;
-    border: 1px solid #e0e0e0;
-    display: flex; /* Flexbox 사용 */
-    justify-content: center; /* 수평 가운데 정렬 */
-    align-items: center; /* 수직 가운데 정렬 */
+  margin-top: 8px;
+  padding: 20px;
+  background-color: #ffffff;
+  border-radius: 15px;
+  border: 1px solid #e0e0e0;
+  display: flex; /* Flexbox 사용 */
+  justify-content: center; /* 수평 가운데 정렬 */
+  align-items: center; /* 수직 가운데 정렬 */
 }
 
 .graph {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 100%; /* 부모 요소 기준으로 너비 설정 */
-    height: 300px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%; /* 부모 요소 기준으로 너비 설정 */
+  height: 500px;
 }
 
 canvas {
-    display: block;
-    width: 100%; /* 전체 너비로 설정 */
-    height: 100%; /* 부모 높이로 설정 */
+  display: block;
+  width: 100%; /* 전체 너비로 설정 */
+  height: 100%; /* 부모 높이로 설정 */
 }
 
-.sub-title{
+.sub-title {
   color: var(--3, #414158);
   font-family: Pretendard;
   font-size: 18px;
@@ -247,14 +260,14 @@ canvas {
   letter-spacing: -0.36px;
 }
 
-.main-title{
-  margin-top : 8xp;
+.main-title {
+  margin-top: 8xp;
   color: var(--3, #414158);
   font-feature-settings: 'dlig' on;
   font-family: Pretendard;
   font-size: 18px;
   font-style: normal;
   font-weight: 700;
-  line-height: 27px; /* 135% */  
+  line-height: 27px; /* 135% */
 }
 </style>

--- a/src/components/modal/goal/AssetGoalDetailModal.vue
+++ b/src/components/modal/goal/AssetGoalDetailModal.vue
@@ -27,7 +27,7 @@
             <!-- 제목 표시 -->
           </div>
           <div class="mb-3" style="display: flex; justify-content: space-between">
-            <label class="form-label" style="font-weight: bold">목표량</label>
+            <label class="form-label" style="font-weight: bold; white-space: nowrap; margin-right: 10px;">목표량</label>
             <div class="input-group" style="text-align: right">
               <!-- 사용자 입력 필드 -->
               <input v-model="goalDetail.amount" type="number" class="form-control" />

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -11,7 +11,7 @@
         <div class="img" :style="{ backgroundImage: 'url(' + richImage + ')' }"></div>
       </div>
 
-      <button id="start-btn">시작하기</button>
+      <button id="start-btn" @click="goToSignIn">시작하기</button>
     </div>
 
     <div class="mid">
@@ -45,7 +45,7 @@
             나의 모든 자산을 확인하세요.
           </p>
         </div>
-        <div class="image-content"></div>
+        <div class="image-content-asset"></div>
       </div>
     </div>
 
@@ -63,7 +63,7 @@
             줄여야 될 소비를 볼 수 있어요.
           </p>
         </div>
-        <div class="image-content"></div>
+        <div class="image-content-consume"></div>
       </div>
     </div>
 
@@ -74,7 +74,7 @@
           <h2 class="title">투자</h2>
 
           <p class="description">
-            나의 투자현황을 <br />
+            나의 투자유형을 <br />
             확인해보세요.
           </p>
           <p class="description-sub">
@@ -82,7 +82,7 @@
             투자유형에 맞는 투자상품을 추천받아요.
           </p>
         </div>
-        <div class="image-content"></div>
+        <div class="image-content-invest"></div>
       </div>
     </div>
 
@@ -97,7 +97,7 @@
             이를 관리해요.
           </p>
         </div>
-        <div class="image-content"></div>
+        <div class="image-content-goal"></div>
       </div>
     </div>
 
@@ -117,7 +117,7 @@
             자산 관리 노하우를 들어봐요!
           </p>
         </div>
-        <div class="image-content"></div>
+        <div class="image-content-community"></div>
       </div>
     </div>
   </div>
@@ -126,8 +126,10 @@
 <script setup>
 import { ref } from 'vue'
 import richImage from '@/assets/images/rich.png'
+import {useRouter} from 'vue-router'
 
 const activeIndex = ref(0)
+const router = useRouter()
 
 function setActive(index, sectionId) {
   activeIndex.value = index
@@ -136,6 +138,11 @@ function setActive(index, sectionId) {
     section.scrollIntoView({ behavior: 'smooth' })
   }
 }
+
+function goToSignIn() {
+  router.push({ path: '/user/signin'})
+}
+
 </script>
 
 <style scoped>
@@ -298,6 +305,61 @@ html {
 }
 
 .image-content {
+  flex: 1;
+  text-align: right;
+  background-image: url('../assets/images/laptop-rich.png');
+  background-size: cover;
+  height: 350px;
+  width: 585px;
+  box-shadow: 0px 4px 8px rgba(25, 24, 29, 0.1);
+  border-radius: 20px;
+}
+
+.image-content-asset {
+  flex: 1;
+  text-align: right;
+  background-image: url('../assets/images/laptop-rich.png');
+  background-size: cover;
+  height: 350px;
+  width: 585px;
+  box-shadow: 0px 4px 8px rgba(25, 24, 29, 0.1);
+  border-radius: 20px;
+}
+
+.image-content-consume {
+  flex: 1;
+  text-align: right;
+  background-image: url('../assets/images/laptop-rich.png');
+  background-size: cover;
+  height: 350px;
+  width: 585px;
+  box-shadow: 0px 4px 8px rgba(25, 24, 29, 0.1);
+  border-radius: 20px;
+}
+
+.image-content-invest {
+  flex: 1;
+  text-align: right;
+  background-image: url('../assets/images/laptop-rich.png');
+  background-size: cover;
+  height: 350px;
+  width: 585px;
+  box-shadow: 0px 4px 8px rgba(25, 24, 29, 0.1);
+  border-radius: 20px;
+}
+
+.image-content-goal {
+  flex: 1;
+  text-align: right;
+  background-image: url('../assets/images/laptop-rich.png');
+  background-size: cover;
+  height: 350px;
+  width: 585px;
+  box-shadow: 0px 4px 8px rgba(25, 24, 29, 0.1);
+  border-radius: 20px;
+}
+
+.image-content-community {
   flex: 1;
   text-align: right;
   background-image: url('../assets/images/laptop-rich.png');

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -1,21 +1,18 @@
 <template>
-<div class="wrap">
+  <div class="wrap">
     <div class="intro_bg">
-      
       <div class="text-center main-container">
         <div class="main-title">나만의 쉬운 금융메이트</div>
         <div class="sub-title">리치블</div>
       </div>
 
-      <div class="img-container"> <!-- 이미지 감싸는 컨테이너 추가 -->
-        <div class="img"></div>
+      <div class="img-container">
+        <!-- 이미지 감싸는 컨테이너 추가 -->
+        <div class="img" :style="{ backgroundImage: 'url(' + richImage + ')' }"></div>
       </div>
 
       <button id="start-btn">시작하기</button>
-
     </div>
-
-
 
     <div class="mid">
       <ul class="mid-nav">
@@ -43,7 +40,10 @@
         <div class="text-content">
           <h2 class="title">자산</h2>
           <p class="description">나의 자산을 한 눈에 <br />모아볼 수 있어요.</p>
-          <p class="description-sub">예/적금, 주식, 채권, 코인, 현물자산 등<br/> 나의 모든 자산을 확인하세요.</p>
+          <p class="description-sub">
+            예/적금, 주식, 채권, 코인, 현물자산 등<br />
+            나의 모든 자산을 확인하세요.
+          </p>
         </div>
         <div class="image-content"></div>
       </div>
@@ -59,7 +59,8 @@
             분석하고 절약해요.
           </p>
           <p class="description-sub">
-            한 달 동안의 소비를 확인하고 <br> 줄여야 될 소비를 볼 수 있어요.
+            한 달 동안의 소비를 확인하고 <br />
+            줄여야 될 소비를 볼 수 있어요.
           </p>
         </div>
         <div class="image-content"></div>
@@ -72,9 +73,13 @@
         <div class="text-content">
           <h2 class="title">투자</h2>
 
-          <p class="description">나의 투자현황을 <br /> 확인해보세요.</p>
+          <p class="description">
+            나의 투자현황을 <br />
+            확인해보세요.
+          </p>
           <p class="description-sub">
-            나의 여유자금을 확인하고 <br> 투자유형에 맞는 투자상품을 추천받아요.
+            나의 여유자금을 확인하고 <br />
+            투자유형에 맞는 투자상품을 추천받아요.
           </p>
         </div>
         <div class="image-content"></div>
@@ -88,7 +93,8 @@
           <h2 class="title">목표</h2>
           <p class="description">나의 목표를 설정해요.</p>
           <p class="description-sub">
-            나의 자산/소비 목표를 설정하고 <br> 이를 관리해요.
+            나의 자산/소비 목표를 설정하고 <br />
+            이를 관리해요.
           </p>
         </div>
         <div class="image-content"></div>
@@ -102,31 +108,32 @@
           <h2 class="title">커뮤니티</h2>
 
           <p class="description">
-            다른 사람들은 어떻게  <br /> 자산을 모을까요?
-          </p>
-          
-          <p class="description-sub">
-            1억 이상의 자산을 가진 리치들의 <br> 자산 관리 노하우를 들어봐요!
+            다른 사람들은 어떻게 <br />
+            자산을 모을까요?
           </p>
 
+          <p class="description-sub">
+            1억 이상의 자산을 가진 리치들의 <br />
+            자산 관리 노하우를 들어봐요!
+          </p>
         </div>
         <div class="image-content"></div>
       </div>
     </div>
   </div>
-  
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref } from 'vue'
+import richImage from '@/assets/images/rich.png'
 
-const activeIndex = ref(0);
+const activeIndex = ref(0)
 
 function setActive(index, sectionId) {
-  activeIndex.value = index;
-  const section = document.querySelector(sectionId);
+  activeIndex.value = index
+  const section = document.querySelector(sectionId)
   if (section) {
-    section.scrollIntoView({ behavior: 'smooth' });
+    section.scrollIntoView({ behavior: 'smooth' })
   }
 }
 </script>
@@ -146,7 +153,7 @@ html {
 }
 
 .intro_bg {
-  background: linear-gradient(180deg, #FFF 0%, #FFF2F6 100%);
+  background: linear-gradient(180deg, #fff 0%, #fff2f6 100%);
   width: 100%;
   height: 640px;
   position: relative;
@@ -155,13 +162,12 @@ html {
   align-items: center; /* 수평 중앙 정렬 */
 }
 
-.main-container{
+.main-container {
   margin-top: 100px;
-
 }
 
-.main-title{
-  color: var(--black-default, #19181D);
+.main-title {
+  color: var(--black-default, #19181d);
   text-align: center;
   font-family: Pretendard;
   font-size: 30px;
@@ -171,8 +177,8 @@ html {
   letter-spacing: -0.8px;
 }
 
-.sub-title{
-  color: var(--black-default, #19181D);
+.sub-title {
+  color: var(--black-default, #19181d);
   text-align: center;
   font-family: Pretendard;
   font-size: 30px;
@@ -190,14 +196,11 @@ html {
 }
 
 .img {
-
-  background-image: url('src/assets/images/rich.png');
   background-size: cover;
   background-repeat: no-repeat;
   height: 170px; /* 높이 설정 */
   width: 188px; /* 너비 설정 */
 }
-
 
 #start-btn {
   width: 150px;
@@ -250,7 +253,7 @@ html {
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  padding:  0;
+  padding: 0;
   background-color: #fff;
 }
 
@@ -263,7 +266,6 @@ html {
   padding: 20px;
   margin-top: px; /* 상단에서 150px 떨어지게 설정 */
 }
-
 
 .text-content {
   flex: 1;
@@ -305,5 +307,4 @@ html {
   box-shadow: 0px 4px 8px rgba(25, 24, 29, 0.1);
   border-radius: 20px;
 }
-
 </style>

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -127,6 +127,7 @@
 import { ref } from 'vue'
 import richImage from '@/assets/images/rich.png'
 import {useRouter} from 'vue-router'
+import axiosInstance from '@/AxiosInstance';
 
 const activeIndex = ref(0)
 const router = useRouter()
@@ -139,8 +140,16 @@ function setActive(index, sectionId) {
   }
 }
 
-function goToSignIn() {
-  router.push({ path: '/user/signin'})
+async function goToSignIn() {
+  const token = localStorage.getItem('authToken'); // 또는 sessionStorage에서 토큰을 가져옴
+  console.log(token);
+  if (token) {
+    // 토큰이 있으면 자산 분석 페이지로 이동
+    router.push({ path: '/asset/analysis' });
+  } else {
+    // 토큰이 없으면 로그인 페이지로 이동
+    router.push({ path: '/user/signin' });
+  }
 }
 
 </script>

--- a/src/views/budget/CompareConsumePage.vue
+++ b/src/views/budget/CompareConsumePage.vue
@@ -11,14 +11,16 @@
 
     <!-- 상단 소비 정보 -->
     <div class="text-center total-asset">
-      <div class="asset-title">{{ diffAmount > 0 ? '이번 달에 아낄 수 있었던 비용이에요 😢' : '이번달에 아낀 비용이에요 😲' }}</div>
+      <div class="asset-title">
+        {{
+          diffAmount > 0 ? '이번 달에 아낄 수 있었던 비용이에요 😢' : '이번달에 아낀 비용이에요 😲'
+        }}
+      </div>
       <div class="asset-amount">{{ Math.abs(couldsaving).toLocaleString() }}원</div>
     </div>
 
-
     <!-- 카테고리 선택 및 비교 -->
     <div class="avg-content">
-
       <div class="text-left category-comparison">
         <div class="sub-title">대한민국 평균 소비금액을 기준으로 비교해요</div>
         <div class="main-title">나는 평균 대비 얼마나 지출할까요?</div>
@@ -26,29 +28,55 @@
 
       <div class="text-center">
         <div class="total-consume">
-            
           <div class="consume-title">
-            나의 이번 달 
-            <select v-model="category" class="form-select custom-inline-select"
-            style="font-size: 18px;font-weight: 700;background-color: none;">
-            <option v-for="option in categories" :key="option" :value="option">{{ option }}</option>
+            나의 이번 달
+            <select
+              v-model="category"
+              class="form-select custom-inline-select"
+              style="font-size: 18px; font-weight: 700; background-color: none"
+            >
+              <option v-for="option in categories" :key="option" :value="option">
+                {{ option }}
+              </option>
             </select>
-            소비는 
+            소비는
           </div>
-         
+
           <div class="consume-title">
             평균보다
-            <span :style="{ color: diffAmount > 0 ? '#EB003B' : '#2768FF', fontSize: '18px', fontWeight: '700' }">
-              {{ Math.abs(diffAmount).toLocaleString() }}원 
+            <span
+              :style="{
+                color: diffAmount > 0 ? '#EB003B' : '#2768FF',
+                fontSize: '18px',
+                fontWeight: '700'
+              }"
+            >
+              {{ Math.abs(diffAmount).toLocaleString() }}원
             </span>
-            <span :style="{ color: diffAmount > 0 ? '#EB003B' : '#2768FF', fontSize: '18px', fontWeight: '700' }"  v-if="diffAmount > 0"> 많습니다</span>
-            <span :style="{ color: diffAmount > 0 ? '#EB003B' : '#2768FF', fontSize: '18px', fontWeight: '700' }" v-else>적습니다</span>.
-
+            <span
+              :style="{
+                color: diffAmount > 0 ? '#EB003B' : '#2768FF',
+                fontSize: '18px',
+                fontWeight: '700'
+              }"
+              v-if="diffAmount > 0"
+            >
+              많습니다</span
+            >
+            <span
+              :style="{
+                color: diffAmount > 0 ? '#EB003B' : '#2768FF',
+                fontSize: '18px',
+                fontWeight: '700'
+              }"
+              v-else
+              >적습니다</span
+            >.
           </div>
-</div>
-     <!-- 차트 -->
-     <div class="chart-container">
-          <canvas style="margin-top: 20px;" id="myChart"></canvas>
+        </div>
+        <!-- 차트 -->
+        <div class="chart-container">
+          <canvas style="margin-top: 20px" id="myChart"></canvas>
         </div>
       </div>
     </div>
@@ -56,27 +84,30 @@
     <!-- 6개월 절역 시뮬레이션 -->
     <div class="saving-content">
       <div class="summary-header">
-          <div class="main-title">6개월 간 소비를 절약했을 때</div>
+        <div class="main-title">6개월 간 소비를 절약했을 때</div>
+      </div>
+
+      <div v-if="possibleSaveAmount.length > 0">
+        <div class="total-consume">
+          <div class="consume-title">
+            이번 달 소비 중 줄일 수 있는 소비는
+            <span style="font-size: 18px; font-weight: 500; color: #ff0062">
+              {{ Math.abs(couldsaving).toLocaleString() }}</span
+            >
+            원 이에요.
+          </div>
+
+          <div class="consume-title">
+            6개월 동안
+            <span style="font-size: 18px; font-weight: 500; color: #ff0062">{{
+              Math.abs(couldsaving * 6).toLocaleString()
+            }}</span>
+            원 절약이 가능해요!
+          </div>
         </div>
 
-        <div v-if="possibleSaveAmount.length > 0" >
-
-          <div class="total-consume">
-            
-            <div class="consume-title">
-              이번 달 소비 중 줄일 수 있는 소비는
-              <span style="font-size: 18px; font-weight: 500; color: #FF0062;">  {{  Math.abs(couldsaving).toLocaleString() }}</span>
-            원 이에요.
-            </div>
-
-            <div class="consume-title">
-              6개월 동안
-              <span style="font-size: 18px; font-weight: 500; color: #FF0062;">{{  Math.abs(couldsaving * 6).toLocaleString() }}</span> 원 절약이 가능해요!
-            </div>
-          </div>
-     
-       <!-- 절약 차트 -->
-       <canvas style="margin-top: 20px;" id="savingChart"></canvas>
+        <!-- 절약 차트 -->
+        <canvas style="margin-top: 20px" id="savingChart"></canvas>
       </div>
     </div>
   </div>
@@ -87,56 +118,68 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { Chart, registerables } from 'chart.js'
 import { nextTick } from 'vue'
 import axiosInstance from '@/AxiosInstance'
-import { useMonthStore } from '@/stores/consume/curMonth.js';
+import { useMonthStore } from '@/stores/consume/curMonth.js'
 
 // 차트.js 등록
 Chart.register(...registerables)
 
-
 // pinia store 사용
 // 달별 네비게이션
-const monthStore = useMonthStore(); // Pinia store 사용
-const curMonth = ref(monthStore.month); // store에서 월 가져오기
-const curYear = ref(monthStore.year);   // store에서 연도 가져오기
-console.log(curMonth, curYear);
+const monthStore = useMonthStore() // Pinia store 사용
+const curMonth = ref(monthStore.month) // store에서 월 가져오기
+const curYear = ref(monthStore.year) // store에서 연도 가져오기
+console.log(curMonth, curYear)
 const category = ref('식료품') // 기본 카테고리를 '식료품'으로 설정
-const categories = ref(['식료품', '유흥', '쇼핑', '공과금', '생활용품', '의료비', '교통비', '통신비', '문화', '교육비', '외식 · 숙박','비소비지출','기타'])
+const categories = ref([
+  '식료품',
+  '유흥',
+  '쇼핑',
+  '공과금',
+  '생활용품',
+  '의료비',
+  '교통비',
+  '통신비',
+  '문화',
+  '교육비',
+  '외식 · 숙박',
+  '비소비지출',
+  '기타'
+])
 const userSpending = ref(0)
 const couldsaving = ref(0)
 const averageSpending = ref(0)
 const diffAmount = computed(() => userSpending.value - averageSpending.value)
-const possibleSaveAmount = ref([]); // 빈 배열로 초기화
-const saveAmount = ref([]); // 빈 배열로 초기화
+const possibleSaveAmount = ref([]) // 빈 배열로 초기화
+const saveAmount = ref([]) // 빈 배열로 초기화
 
 // 통화 포맷 함수
 const formatCurrency = (amount) => {
   if (amount >= 100000) {
-    return `${(amount / 10000).toFixed(0)}만원`;
+    return `${(amount / 10000).toFixed(0)}만원`
   } else {
-    return `${amount.toLocaleString()}원`;
+    return `${amount.toLocaleString()}원`
   }
-};
-
+}
 
 const wordMapping2 = {
-'식료품': '식료품 · 비주류음료',
-'유흥': '주류 · 담배',
-'쇼핑': '의류 · 신발',
-'공과금': '주거 · 수도 · 광열',
-'생활용품': '가정용품 · 가사서비스',
-'의료비': '보건',
-'교통비': '교통',
-'통신비': '통신',
-'문화': '오락 · 문화',
-'교육비': '교육',
-'외식 · 숙박': '음식 · 숙박',
-'기타': '기타상품 · 서비스',
-'비소비지출' : '비소비지출'
-};
+  식료품: '식료품 · 비주류음료',
+  유흥: '주류 · 담배',
+  쇼핑: '의류 · 신발',
+  공과금: '주거 · 수도 · 광열',
+  생활용품: '가정용품 · 가사서비스',
+  의료비: '보건',
+  교통비: '교통',
+  통신비: '통신',
+  문화: '오락 · 문화',
+  교육비: '교육',
+  '외식 · 숙박': '음식 · 숙박',
+  기타: '기타상품 · 서비스',
+  비소비지출: '비소비지출'
+}
 
 // 매핑 함수
 function mapColumnToKeyword2(keyword) {
-return wordMapping2[keyword] || '매핑되지 않은 컬럼';
+  return wordMapping2[keyword] || '매핑되지 않은 컬럼'
 }
 
 // 차트 초기화 변수
@@ -145,100 +188,97 @@ let savingChart = null
 
 // 이전/다음 달 버튼 클릭 시
 const previousMonth = () => {
-  const { year: updatedYear, month: updatedMonth } = monthStore.decreaseMonth();
-  curMonth.value = updatedMonth;
-  curYear.value = updatedYear;
+  const { year: updatedYear, month: updatedMonth } = monthStore.decreaseMonth()
+  curMonth.value = updatedMonth
+  curYear.value = updatedYear
 
-  fetchComparisonData();   // 데이터를 다시 가져오기
-  fetchCouldSaving();
-  fetchSimulationData();
+  fetchComparisonData() // 데이터를 다시 가져오기
+  fetchCouldSaving()
+  fetchSimulationData()
 }
 
 const nextMonth = () => {
-  const { year: updatedYear, month: updatedMonth } = monthStore.increaseMonth();
-  curMonth.value = updatedMonth;
-  curYear.value = updatedYear;
+  const { year: updatedYear, month: updatedMonth } = monthStore.increaseMonth()
+  curMonth.value = updatedMonth
+  curYear.value = updatedYear
 
-  fetchComparisonData();   // 데이터를 다시 가져오기
-  fetchCouldSaving();
-  fetchSimulationData();
-};
+  fetchComparisonData() // 데이터를 다시 가져오기
+  fetchCouldSaving()
+  fetchSimulationData()
+}
 
 // 카테고리 변경 시 데이터 가져오기
 watch(category, () => {
-fetchComparisonData();
-});
+  fetchComparisonData()
+})
 
 // 월과 연도 변경 시 데이터 업데이트
 watch([curMonth, curYear], () => {
   fetchCouldSaving()
   fetchSimulationData()
-  fetchComparisonData();
-});
+  fetchComparisonData()
+})
 
 // 소비 비교 데이터를 API에서 가져와 차트에 반영
 const fetchComparisonData = async () => {
-  const cntYear = curYear.value;
-  const cntMonth = curMonth.value;
+  const cntYear = curYear.value
+  const cntMonth = curMonth.value
 
+  const tempCategory = mapColumnToKeyword2(category.value) // category의 매핑된 값을 가져옴
+  const encodedCategory = encodeURIComponent(tempCategory) // 카테고리를 URL 인코딩
+  const response = await axiosInstance.get(
+    `/outcome/compare/${cntYear}/${cntMonth}/${encodedCategory}`
+  )
 
-  const tempCategory = mapColumnToKeyword2(category.value); // category의 매핑된 값을 가져옴
-  const encodedCategory = encodeURIComponent(tempCategory); // 카테고리를 URL 인코딩
-  const response = await axiosInstance.get(`/outcome/compare/${cntYear}/${cntMonth}/${encodedCategory}`);
-  
-  const data = response.data.response.data;
-  userSpending.value = data.mySum;
-  averageSpending.value = data.averageSum;
-  console.log(userSpending.value, averageSpending.value);
-  
-  createComparisonChart(); // 데이터를 받아온 후 차트 생성
-};
+  const data = response.data.response.data
+  userSpending.value = data.mySum
+  averageSpending.value = data.averageSum
+  console.log(userSpending.value, averageSpending.value)
+
+  createComparisonChart() // 데이터를 받아온 후 차트 생성
+}
 
 // 이번달 아낄 수 있었던 비용
 const fetchCouldSaving = async () => {
-  const cntYear = curYear.value;
-  const cntMonth = curMonth.value;
+  const cntYear = curYear.value
+  const cntMonth = curMonth.value
 
-  const response = await axiosInstance.get(`/outcome/review/sum/${cntYear}/${cntMonth}`);
-  const data = response.data.response.data;
-  couldsaving.value = Math.abs(data.possibleSaveAmount); // 음수값을 절대값으로 변환
-  console.log(couldsaving.value);
-
-};
+  const response = await axiosInstance.get(`/outcome/review/sum/${cntYear}/${cntMonth}`)
+  const data = response.data.response.data
+  couldsaving.value = Math.abs(data.possibleSaveAmount) // 음수값을 절대값으로 변환
+  console.log(couldsaving.value)
+}
 
 // 6개월 절약 시뮬레이션 데이터 가져오기
 const fetchSimulationData = async () => {
-  const cntYear = curYear.value;
-  const cntMonth = curMonth.value;
+  const cntYear = curYear.value
+  const cntMonth = curMonth.value
 
-    const response = await axiosInstance.get(`/outcome/simulation/${cntYear}/${cntMonth}`);
-    const data = response.data.response.data;
-console.log(data);
+  const response = await axiosInstance.get(`/outcome/simulation/${cntYear}/${cntMonth}`)
+  const data = response.data.response.data
+  console.log(data)
 
-    possibleSaveAmount.value = data.possibleSaveAmount.map(amount => Math.abs(amount));
-    saveAmount.value = data.saveAmount.map(amount => Math.abs(amount));
+  possibleSaveAmount.value = data.possibleSaveAmount.map((amount) => Math.abs(amount))
+  saveAmount.value = data.saveAmount.map((amount) => Math.abs(amount))
 
-    nextTick(() => {
-      const canvasElement = document.getElementById('savingChart');
-      if (canvasElement) {
-        const ctx = canvasElement.getContext('2d');
-        if(ctx) {
-        createSavingChart(data.months, saveAmount.value, possibleSaveAmount.value);
+  nextTick(() => {
+    const canvasElement = document.getElementById('savingChart')
+    if (canvasElement) {
+      const ctx = canvasElement.getContext('2d')
+      if (ctx) {
+        createSavingChart(data.months, saveAmount.value, possibleSaveAmount.value)
       } else {
-        console.error('Cannot find canvas element for savingChart');
+        console.error('Cannot find canvas element for savingChart')
       }
     }
   })
-};
-  
-
-
+}
 
 // 막대 그래프 생성
 const createComparisonChart = () => {
-  const ctx1 = document.getElementById('myChart').getContext('2d');
+  const ctx1 = document.getElementById('myChart').getContext('2d')
 
-  if (myChart) myChart.destroy(); // 이전 차트 삭제
+  if (myChart) myChart.destroy() // 이전 차트 삭제
 
   // 카테고리 비교 차트
   myChart = new Chart(ctx1, {
@@ -252,94 +292,97 @@ const createComparisonChart = () => {
           backgroundColor: ['#d3d3d3', '#ff6384'],
           borderWidth: 1,
           borderRadius: 10,
-          barThickness: 50,
-        },
-      ],
+          barThickness: 50
+        }
+      ]
     },
     options: {
       responsive: true,
       layout: {
         padding: {
-          top: 20, // 그래프 상단에 패딩 추가
-        },
+          top: 20 // 그래프 상단에 패딩 추가
+        }
       },
       scales: {
         y: {
           grid: {
-            display: false, // y축 배경선 숨기기
+            display: false // y축 배경선 숨기기
           },
           beginAtZero: true,
           ticks: {
             callback: function (value) {
-              return value.toLocaleString() + '원'; // y축에 '원' 추가
-            },
-          },
+              return value.toLocaleString() + '원' // y축에 '원' 추가
+            }
+          }
         },
         x: {
           grid: {
-            display: false, // x축 배경선 숨기기
+            display: false // x축 배경선 숨기기
           },
           ticks: {
-            color: '#767676', // x축 라벨 색상
-          },
-        },
+            color: '#767676' // x축 라벨 색상
+          }
+        }
       },
       plugins: {
         legend: {
-          display: false, // 범례 비활성화
+          display: false // 범례 비활성화
         },
         tooltip: {
           callbacks: {
             label: function (tooltipItem) {
-              return tooltipItem.raw.toLocaleString() + '원'; // 툴팁에 '원' 추가
-            },
-          },
-        },
-      },
+              return tooltipItem.raw.toLocaleString() + '원' // 툴팁에 '원' 추가
+            }
+          }
+        }
+      }
     },
     plugins: [
       {
         id: 'barLabels',
         afterDatasetsDraw(chart) {
-          const { ctx, data, scales: { x, y } } = chart;
+          const {
+            ctx,
+            data,
+            scales: { x, y }
+          } = chart
 
-          ctx.save();
-          ctx.font = '12px Pretendard';
-          ctx.fillStyle = '#767676';
-          ctx.textAlign = 'center';
-          ctx.textBaseline = 'bottom';
+          ctx.save()
+          ctx.font = '12px Pretendard'
+          ctx.fillStyle = '#767676'
+          ctx.textAlign = 'center'
+          ctx.textBaseline = 'bottom'
 
           data.datasets.forEach((dataset, i) => {
             chart.getDatasetMeta(i).data.forEach((bar, index) => {
-              const value = dataset.data[index];
-              const formattedValue = value >= 100000 
-                ? `${Math.floor(value / 10000)}만원` // Use Math.floor() to truncate instead of rounding
-                : `${value.toLocaleString()}원`;
+              const value = dataset.data[index]
+              const formattedValue =
+                value >= 100000
+                  ? `${Math.floor(value / 10000)}만원` // Use Math.floor() to truncate instead of rounding
+                  : `${value.toLocaleString()}원`
 
-              ctx.fillText(formattedValue, bar.x, bar.y - 5);
-            });
-          });
+              ctx.fillText(formattedValue, bar.x, bar.y - 5)
+            })
+          })
 
-          ctx.restore();
-        },
-      },
-    ],
-  });
-};
+          ctx.restore()
+        }
+      }
+    ]
+  })
+}
 
+const createSavingChart = (months, saveAmount, possibleSaveAmount) => {
+  const ctx2 = document.getElementById('savingChart')?.getContext('2d')
 
-  const createSavingChart = (months, saveAmount, possibleSaveAmount) => {
-  const ctx2 = document.getElementById('savingChart')?.getContext('2d');
-  
   if (!ctx2) {
-    console.error('Cannot get context for savingChart');
-    return;
+    console.error('Cannot get context for savingChart')
+    return
   }
 
-  if (savingChart) savingChart.destroy(); // 기존 차트가 있으면 삭제
+  if (savingChart) savingChart.destroy() // 기존 차트가 있으면 삭제
 
-
-  console.log(saveAmount, possibleSaveAmount);
+  console.log(saveAmount, possibleSaveAmount)
 
   savingChart = new Chart(ctx2, {
     type: 'line',
@@ -351,16 +394,16 @@ const createComparisonChart = () => {
           data: saveAmount,
           borderColor: '#FF6384',
           fill: false,
-          borderWidth: 2,
+          borderWidth: 2
         },
         {
           label: '평소 저축',
           data: possibleSaveAmount,
           borderColor: '#D3D3D3',
           fill: false,
-          borderWidth: 2,
-        },
-      ],
+          borderWidth: 2
+        }
+      ]
     },
     options: {
       responsive: true,
@@ -369,52 +412,48 @@ const createComparisonChart = () => {
           beginAtZero: true,
           ticks: {
             callback: function (value) {
-              return value.toLocaleString() + '원';
-            },
-          },
-        },
+              return value.toLocaleString() + '원'
+            }
+          }
+        }
       },
       plugins: {
         legend: {
-          position: 'bottom', // 범례를 아래로 이동
+          position: 'bottom' // 범례를 아래로 이동
         },
         tooltip: {
           callbacks: {
             label: function (tooltipItem) {
-              return tooltipItem.raw.toLocaleString() + '원';
-            },
-          },
-        },
-      },
-    },
-  });
-};
-
-
+              return tooltipItem.raw.toLocaleString() + '원'
+            }
+          }
+        }
+      }
+    }
+  })
+}
 
 // 페이지 로드 시 데이터 가져오기
 onMounted(() => {
-  fetchComparisonData(); // 초기 로드 시 데이터 가져오기
-  fetchCouldSaving();     // 절약 가능 금액 데이터 가져오기
-  fetchSimulationData();  // 시뮬레이션 데이터 가져오기
+  fetchComparisonData() // 초기 로드 시 데이터 가져오기
+  fetchCouldSaving() // 절약 가능 금액 데이터 가져오기
+  fetchSimulationData() // 시뮬레이션 데이터 가져오기
 
-  curMonth.value = monthStore.month;
-  curYear.value = monthStore.year;
-});
-
+  curMonth.value = monthStore.month
+  curYear.value = monthStore.year
+})
 </script>
 
 <style scoped>
-
 * {
   font-family: pretendard;
-  color: #19181D;
+  color: #19181d;
   font-size: 20px;
   max-width: 1704px;
 }
 
 .container {
- margin: 80px;
+  margin: 80px;
 }
 
 .total-asset {
@@ -435,7 +474,7 @@ onMounted(() => {
 }
 
 .asset-title {
-  color: var(--black-default, #19181D);
+  color: var(--black-default, #19181d);
   text-align: center;
   font-family: Pretendard;
   font-size: 20px;
@@ -446,7 +485,7 @@ onMounted(() => {
 }
 
 .asset-amount {
-  color: var(--black-default, #19181D);
+  color: var(--black-default, #19181d);
   text-align: center;
   font-family: Pretendard;
   font-size: 24px;
@@ -456,11 +495,11 @@ onMounted(() => {
   letter-spacing: -0.48px;
 }
 
-.total-consume{
+.total-consume {
   margin-top: 21px;
   flex-shrink: 0;
   border-radius: 20px;
-  background: #FAFAFB;
+  background: #fafafb;
   display: flex;
   height: 125px;
   padding: 10px 10px 10px 10px;
@@ -480,14 +519,10 @@ onMounted(() => {
   width: 100%;
   height: auto;
   padding: 20px; /* 패딩으로 차트 여백 확보 */
-  background: #FAFAFB;
 }
 
-
-
-
-.consume-title{
-  color: var(--black-default, #19181D);
+.consume-title {
+  color: var(--black-default, #19181d);
   text-align: center;
   font-feature-settings: 'dlig' on;
   font-family: Pretendard;
@@ -498,13 +533,12 @@ onMounted(() => {
   letter-spacing: -0.8px;
 }
 
-.avg-content{
+.avg-content {
   margin-top: 100px;
 }
 
-.saving-content{
+.saving-content {
   margin-top: 100px;
-  
 }
 
 #myChart {
@@ -516,7 +550,6 @@ onMounted(() => {
   border-radius: 20px;
   border: 1px solid #e4ebf0;
 }
-
 
 /* 월 네비게이션 */
 .month-navigation {
@@ -531,7 +564,7 @@ onMounted(() => {
   font-size: 24px;
 }
 
-.sub-title{
+.sub-title {
   color: var(--3, #414158);
   font-family: Pretendard;
   font-size: 18px;
@@ -541,15 +574,15 @@ onMounted(() => {
   letter-spacing: -0.36px;
 }
 
-.main-title{
-  margin-top : 8xp;
+.main-title {
+  margin-top: 8xp;
   color: var(--3, #414158);
   font-feature-settings: 'dlig' on;
   font-family: Pretendard;
   font-size: 18px;
   font-style: normal;
   font-weight: 700;
-  line-height: 27px; /* 135% */  
+  line-height: 27px; /* 135% */
 }
 
 .custom-btn-left,
@@ -606,7 +639,6 @@ onMounted(() => {
   padding: 20px;
   border-radius: 10px;
   text-align: center;
-  
 }
 
 .savings-summary-container h4 {

--- a/src/views/goal/GoalAssetListPage.vue
+++ b/src/views/goal/GoalAssetListPage.vue
@@ -379,7 +379,7 @@ line-height: 27px; /* 112.5% */
 .goal-cards {
   margin-top: 16px;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 20px;
 }
 

--- a/src/views/user/SignInPage.vue
+++ b/src/views/user/SignInPage.vue
@@ -42,10 +42,9 @@
       <span class="mx-2"> | </span>
       <router-link to="/user/findpassword" class="join-link">비밀번호 찾기</router-link>
     </div>
-    <div class="or-divider">또는</div>
+    <div class="or-divider">또는</div> 
 
     <div class="sns-buttons">
-      <img src="https://via.placeholder.com/40?text=K" alt="Kakao" />
       <img src="../../assets/images/naver.png" alt="Naver" @click="naverLogin" />
     </div>
 
@@ -116,7 +115,7 @@ const handleNaverCallback = async () => {
         if (redirectUrl) {
           window.location.href = redirectUrl // 전체 페이지 리로드
         } else {
-          router.push({ name: 'home' })
+          router.push({ name: 'assetAnalysis' })
         }
       } else {
         throw new Error('Invalid response format')
@@ -146,7 +145,7 @@ const login = async () => {
       // 로그인 성공 시 처리
       alert('Login successful!');
       localStorage.setItem('authToken', token);
-      router.push({ name: 'home' });
+      router.push({ name: 'assetAnalysis' });
     } else {
       throw new Error('Invalid response format');
     }


### PR DESCRIPTION
소득/소비
1. 전달 소비 누계 비교 text 띄어쓰기 수정
3. 그래프 간격(너비) 수정 -> height 늘림.
4. 소비 테이블에서 클릭 시 해당 카테고리 상세 조회로 이동하기 . 그 외는 모달로 표기 -> '그 외' 카테고리는 모달로 값 표시 기능 유지. 나머지는 소득/소비 페이지로 router연결

목표 자산관리
1. 최대 항목 수 줄 바꿈 -> 한 줄에 3개 씩 소비 카드 배치
2. 금액 입력시 '목표량'키워드 줄 바꿈 수정

로그인/ 홈
1. 소셜로그인 -> 카카오 소셜 로그인 삭제
2. 홈 화면 씨앗 이미지 -> CSS에 이미지 url설정 후 사용에서, 이미지 파일을 직접 import하는 방식으로 변경.
3. 시작 버튼 누르면 로그인x시 로그인 화면으로 이동.
로그인 했으면, 자산 분석 페이지로 이동